### PR TITLE
Add dot formatter (Graphviz)

### DIFF
--- a/lib/rpr.rb
+++ b/lib/rpr.rb
@@ -19,8 +19,8 @@ module Rpr
         puts VERSION
       end
 
-      formatter = find_formatter(options[:formatter])
       parser = find_parser(options[:parser])
+      formatter = find_formatter(options[:formatter])
 
       if options[:expression]
         res = parser.parse(options[:expression])

--- a/lib/rpr/formatter/dot.rb
+++ b/lib/rpr/formatter/dot.rb
@@ -1,0 +1,92 @@
+module Rpr
+  module Formatter
+    module UnifiedInterface
+      refine Object do
+        def node_value() inspect end
+        def traversable?() false end
+      end
+
+      if defined?(Rpr::Parser::Sexp)
+        refine Array do
+          def node_value() traversable? ? self[0].to_s : super end
+          def children
+            res = []
+            self[1..-1].each do |child|
+              if child.is_a?(Array) &&
+                 !child.traversable? &&
+                 !(child.size == 2 && child[0].is_a?(Integer) && child[1].is_a?(Integer))
+                res.concat(child)
+              else
+                res << child
+              end
+            end
+            res
+          end
+          def traversable?() self.first.is_a?(Symbol) end
+        end
+      end
+
+      if defined?(Rpr::Parser::Parser) || defined?(Rpr::Parser::Rubocop)
+        refine ::Parser::AST::Node do
+          def node_value() self.type.to_s end
+          def traversable?() true end
+        end
+      end
+
+      if defined?(Rpr::Parser::Rubyparser)
+        refine Sexp do
+          def node_value() self.sexp_type.to_s end
+          def children() self.each.to_a end
+          def traversable?() true end
+        end
+      end
+
+      if defined?(Rpr::Parser::Rubyvm_ast)
+        refine RubyVM::AbstractSyntaxTree::Node do
+          def node_value() self.type.to_s end
+          def traversable?() true end
+        end
+      end
+    end
+
+    # Formatter for Graphviz
+    class Dot
+      using UnifiedInterface
+
+      def self.print(object)
+        self.new.print(object)
+      end
+
+      def initialize
+        @id = :a
+      end
+
+      def print(object)
+        puts 'digraph{graph [dpi=288;];'
+        traverse_and_print(object)
+        puts "}"
+      end
+
+      private
+
+      def traverse_and_print(object, parent = 'ROOT')
+        label = object.node_value
+        shape = object.traversable? ? 'oval' : 'box'
+        id = gen_id()
+
+        puts "#{id} -> #{parent}"
+        puts "#{id}[ label=#{label.inspect} shape=#{shape} ]"
+
+        if object.traversable?
+          object.children.each do |child|
+            traverse_and_print(child, id)
+          end
+        end
+      end
+
+      def gen_id
+        @id = @id.succ
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref: https://qiita.com/Nabetani/items/7904651fae1f925129c7


Note: It is experimental, and Dot formatter supports limited parsers (`Ripper.sexp`, `Parser`, `RubyParser`, and `RubyVM::AST`).


This formatter displays Dot language for Graphviz.
For example:

```bash
$ rpr -p rubyvm_ast -e 'p 1 + 1' -f dot
digraph{graph [dpi=288;];
b -> ROOT
b[ label="SCOPE" shape=oval ]
c -> b
c[ label="[]" shape=box ]
d -> b
d[ label="nil" shape=box ]
e -> b
e[ label="FCALL" shape=oval ]
f -> e
f[ label=":p" shape=box ]
g -> e
g[ label="ARRAY" shape=oval ]
h -> g
h[ label="OPCALL" shape=oval ]
i -> h
i[ label="LIT" shape=oval ]
j -> i
j[ label="1" shape=box ]
k -> h
k[ label=":+" shape=box ]
l -> h
l[ label="ARRAY" shape=oval ]
m -> l
m[ label="LIT" shape=oval ]
n -> m
n[ label="1" shape=box ]
o -> l
o[ label="nil" shape=box ]
p -> g
p[ label="nil" shape=box ]
}
```

Convert to PNG

```bash
$ rpr -p rubyvm_ast -e 'p 1 + 1' -f dot | dot -Tpng -oast.png
$ open ast.png
```

![ast](https://user-images.githubusercontent.com/4361134/50540790-cb6a5e80-0bdb-11e9-9f95-ce766ad620d5.png)
